### PR TITLE
Android Build tools, booleans, optional thread hanging, documentation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ project.group = 'de.tomgrill.gdxdialogs.android'
 android {
 
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 9

--- a/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXButtonDialog.java
+++ b/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXButtonDialog.java
@@ -56,38 +56,24 @@ public class AndroidGDXButtonDialog implements GDXButtonDialog {
 		return this;
 	}
 
-	/**
-	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior. The boolean hangs the current thread if true.
-	 *
-	 *
-	 * @param hang if true hangs the thread witch it were called from
-	 * @return The same instance that the method was called from.
-	 */
-	public GDXButtonDialog show(boolean hang) {
+	@Override
+	public GDXButtonDialog show() {
 
 		if (dialog == null || !isBuild) {
 			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been built. Use build() " +
 					"before show().");
 		}
 
-		Runnable r = new Runnable() {
+		activity.runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Gdx.app.debug(GDXDialogsVars.LOG_TAG, AndroidGDXButtonDialog.class.getSimpleName() +
 						" now shown.");
 				dialog.show();
 			}
-		};
+		});
 
-		if (hang) r.run();
-		else activity.runOnUiThread(r);
 		return this;
-	}
-
-	@Override
-	public GDXButtonDialog show() {
-		return show(false);
 	}
 
 	@Override
@@ -183,6 +169,7 @@ public class AndroidGDXButtonDialog implements GDXButtonDialog {
 			try {
 				Thread.sleep(10);
 			} catch (InterruptedException e) {
+				//Not meant to run but we better know when it does.
 				e.printStackTrace();
 			}
 		}

--- a/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXButtonDialog.java
+++ b/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXButtonDialog.java
@@ -56,37 +56,52 @@ public class AndroidGDXButtonDialog implements GDXButtonDialog {
 		return this;
 	}
 
-	@Override
-	public GDXButtonDialog show() {
+	/**
+	 * Shows the dialog. show() can only be called after build() has been called
+	 * else there might be strange behavior. The boolean hangs the current thread if true.
+	 *
+	 *
+	 * @param hang if true hangs the thread witch it were called from
+	 * @return The same instance that the method was called from.
+	 */
+	public GDXButtonDialog show(boolean hang) {
 
-		if (dialog == null || isBuild == false) {
-			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() before show().");
+		if (dialog == null || !isBuild) {
+			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been built. Use build() " +
+					"before show().");
 		}
 
-		activity.runOnUiThread(new Runnable() {
+		Runnable r = new Runnable() {
 			@Override
 			public void run() {
-				Gdx.app.debug(GDXDialogsVars.LOG_TAG, AndroidGDXButtonDialog.class.getSimpleName() + " now shown.");
+				Gdx.app.debug(GDXDialogsVars.LOG_TAG, AndroidGDXButtonDialog.class.getSimpleName() +
+						" now shown.");
 				dialog.show();
 			}
-		});
+		};
+
+		if (hang) r.run();
+		else activity.runOnUiThread(r);
 		return this;
+	}
+
+	@Override
+	public GDXButtonDialog show() {
+		return show(false);
 	}
 
 	@Override
 	public GDXButtonDialog dismiss() {
 
-		if (dialog == null || isBuild == false) {
-			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() before dismiss().");
+		if (dialog == null || !isBuild) {
+			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() " +
+					"before dismiss().");
 		}
 
-		activity.runOnUiThread(new Runnable() {
-			@Override
-			public void run() {
-				Gdx.app.debug(GDXDialogsVars.LOG_TAG, AndroidGDXButtonDialog.class.getSimpleName() + " dismissed.");
-				dialog.dismiss();
-			}
-		});
+		Gdx.app.debug(GDXDialogsVars.LOG_TAG, AndroidGDXButtonDialog.class.getSimpleName() +
+				" dismissed.");
+		dialog.dismiss(); //This method is thread safe.
+
 		return this;
 	}
 
@@ -163,11 +178,12 @@ public class AndroidGDXButtonDialog implements GDXButtonDialog {
 			}
 		});
 
-		// Wait till button is build
+		// Wait until the button is built
 		while (!isBuild) {
 			try {
 				Thread.sleep(10);
 			} catch (InterruptedException e) {
+				e.printStackTrace();
 			}
 		}
 

--- a/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXProgressDialog.java
+++ b/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXProgressDialog.java
@@ -50,37 +50,22 @@ public class AndroidGDXProgressDialog implements GDXProgressDialog {
 		return this;
 	}
 
-	/**
-	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior. The boolean hangs the current thread if true.
-	 *
-	 *
-	 * @param hang if true hangs the thread witch it were called from
-	 * @return The same instance that the method was called from.
-	 */
-	public GDXProgressDialog show(boolean hang) {
+	@Override
+	public GDXProgressDialog show() {
 		if (progressDialog == null || !isBuild) {
 			throw new RuntimeException(AndroidGDXProgressDialog.class.getSimpleName() + " has not been build. Use"+
 					" build() before show().");
 		}
 
-		Runnable r = new Runnable() {
+		activity.runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Gdx.app.debug(GDXDialogsVars.LOG_TAG, GDXProgressDialog.class.getSimpleName() + " now shown.");
 				progressDialog.show();
 			}
-		};
-
-		if (hang) r.run();
-		else activity.runOnUiThread(r);
+		});
 
 		return this;
-	}
-
-	@Override
-	public GDXProgressDialog show() {
-		return show(false);
 	}
 
 	@Override

--- a/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXProgressDialog.java
+++ b/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXProgressDialog.java
@@ -50,37 +50,49 @@ public class AndroidGDXProgressDialog implements GDXProgressDialog {
 		return this;
 	}
 
-	@Override
-	public GDXProgressDialog show() {
-		if (progressDialog == null || isBuild == false) {
-			throw new RuntimeException(AndroidGDXProgressDialog.class.getSimpleName() + " has not been build. Use build() before show().");
+	/**
+	 * Shows the dialog. show() can only be called after build() has been called
+	 * else there might be strange behavior. The boolean hangs the current thread if true.
+	 *
+	 *
+	 * @param hang if true hangs the thread witch it were called from
+	 * @return The same instance that the method was called from.
+	 */
+	public GDXProgressDialog show(boolean hang) {
+		if (progressDialog == null || !isBuild) {
+			throw new RuntimeException(AndroidGDXProgressDialog.class.getSimpleName() + " has not been build. Use"+
+					" build() before show().");
 		}
 
-		activity.runOnUiThread(new Runnable() {
+		Runnable r = new Runnable() {
 			@Override
 			public void run() {
 				Gdx.app.debug(GDXDialogsVars.LOG_TAG, GDXProgressDialog.class.getSimpleName() + " now shown.");
 				progressDialog.show();
 			}
-		});
+		};
+
+		if (hang) r.run();
+		else activity.runOnUiThread(r);
 
 		return this;
 	}
 
 	@Override
+	public GDXProgressDialog show() {
+		return show(false);
+	}
+
+	@Override
 	public GDXProgressDialog dismiss() {
 
-		if (progressDialog == null || isBuild == false) {
-			throw new RuntimeException(AndroidGDXProgressDialog.class.getSimpleName() + " has not been build. Use build() before dismiss().");
+		if (progressDialog == null || !isBuild) {
+			throw new RuntimeException(AndroidGDXProgressDialog.class.getSimpleName() + " has not been build. Use "+
+					"build() before dismiss().");
 		}
 
-		activity.runOnUiThread(new Runnable() {
-			@Override
-			public void run() {
-				Gdx.app.debug(GDXDialogsVars.LOG_TAG, GDXProgressDialog.class.getSimpleName() + " dismissed.");
-				progressDialog.dismiss();
-			}
-		});
+		Gdx.app.debug(GDXDialogsVars.LOG_TAG, GDXProgressDialog.class.getSimpleName() + " dismissed.");
+		progressDialog.dismiss(); // Method is thread safe.
 
 		return this;
 	}
@@ -107,6 +119,7 @@ public class AndroidGDXProgressDialog implements GDXProgressDialog {
 				try {
 					Thread.sleep(10);
 				} catch (InterruptedException e) {
+					e.printStackTrace(); //It's never supposed to happen, I know, but if it does, we better know.
 				}
 			}
 		}

--- a/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXTextPrompt.java
+++ b/android/src/de/tomgrill/gdxdialogs/android/dialogs/AndroidGDXTextPrompt.java
@@ -56,17 +56,12 @@ public class AndroidGDXTextPrompt implements GDXTextPrompt {
 		this.activity = activity;
 	}
 
-	/**
-	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior. The boolean hangs the current thread if true.
-	 *
-	 *
-	 * @param hang if true hangs the thread witch it were called from
-	 * @return The same instance that the method was called from.
-	 */
-	public GDXTextPrompt show(boolean hang) {
+
+	@Override
+	public GDXTextPrompt show() {
 		if (alertDialog == null || !isBuild) {
-			throw new RuntimeException(GDXTextPrompt.class.getSimpleName() + " has not been build. Use build() before show().");
+			throw new RuntimeException(GDXTextPrompt.class.getSimpleName() + " has not been build. Use build() before" +
+					" show().");
 		}
 
 		// When alert dialog is null, an except. is thrown and the code never gets here. No point in checking
@@ -74,23 +69,15 @@ public class AndroidGDXTextPrompt implements GDXTextPrompt {
 			userInput.setText(inputValue);
 		}
 
-		Runnable r = new Runnable() {
+		activity.runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Gdx.app.debug(GDXDialogsVars.LOG_TAG, AndroidGDXTextPrompt.class.getSimpleName() + " now shown.");
 				alertDialog.show();
 			}
-		};
-
-		if (hang) r.run();
-		else activity.runOnUiThread(r);
+		});
 
 		return this;
-	}
-
-	@Override
-	public GDXTextPrompt show() {
-		return show(false);
 	}
 
 	@Override
@@ -104,7 +91,8 @@ public class AndroidGDXTextPrompt implements GDXTextPrompt {
 				LayoutInflater li = LayoutInflater.from(activity);
 				//
 
-				View promptsView = li.inflate(getResourceId("gdxdialogs_inputtext", "layout"), null);
+				View promptsView = li.inflate(getResourceId("gdxdialogs_inputtext", "layout"),
+                        null);
 
 				alertDialogBuilder.setView(promptsView);
 
@@ -143,6 +131,8 @@ public class AndroidGDXTextPrompt implements GDXTextPrompt {
 			try {
 				Thread.sleep(10);
 			} catch (InterruptedException e) {
+			    //Again, never supposed to run, never hurts to know if it does.
+			    e.printStackTrace();
 			}
 		}
 
@@ -153,7 +143,8 @@ public class AndroidGDXTextPrompt implements GDXTextPrompt {
 		try {
 			return activity.getResources().getIdentifier(pVariableName, pVariableType, activity.getPackageName());
 		} catch (Exception e) {
-			Gdx.app.error(GDXDialogsVars.LOG_TAG, "Cannot find resouce with name: " + pVariableName + " Did you copy the layouts to /res/layouts and /res/layouts_v14 ?");
+			Gdx.app.error(GDXDialogsVars.LOG_TAG, "Cannot find resouce with name: " + pVariableName +
+                    " Did you copy the layouts to /res/layouts and /res/layouts_v14 ?");
 			e.printStackTrace();
 			return -1;
 		}
@@ -199,7 +190,8 @@ public class AndroidGDXTextPrompt implements GDXTextPrompt {
 	public GDXTextPrompt dismiss() {
 
 		if (alertDialog == null || !isBuild) {
-			throw new RuntimeException(GDXTextPrompt.class.getSimpleName() + " has not been build. Use build() before dismiss().");
+			throw new RuntimeException(GDXTextPrompt.class.getSimpleName() + " has not been build. Use build() " +
+                    "before dismiss().");
 		}
 
 		Gdx.app.debug(GDXDialogsVars.LOG_TAG, AndroidGDXTextPrompt.class.getSimpleName() + " dismissed.");

--- a/core/src/de/tomgrill/gdxdialogs/core/dialogs/FallbackGDXTextPrompt.java
+++ b/core/src/de/tomgrill/gdxdialogs/core/dialogs/FallbackGDXTextPrompt.java
@@ -25,7 +25,8 @@ public class FallbackGDXTextPrompt implements GDXTextPrompt {
 
 	@Override
 	public GDXTextPrompt show() {
-		Gdx.app.debug(GDXDialogsVars.LOG_TAG, FallbackGDXTextPrompt.class.getSimpleName() + " now shown ignored. (Fallback with empty methods)");
+		Gdx.app.debug(GDXDialogsVars.LOG_TAG, FallbackGDXTextPrompt.class.getSimpleName() + " now shown " +
+				"ignored. (Fallback with empty methods)");
 		return this;
 	}
 
@@ -60,13 +61,14 @@ public class FallbackGDXTextPrompt implements GDXTextPrompt {
 	}
 
 	@Override
-	public GDXTextPrompt setValue(CharSequence message) {
+	public GDXTextPrompt setValue(CharSequence inputTip) {
 		return this;
 	}
 
 	@Override
 	public GDXTextPrompt dismiss() {
-		Gdx.app.debug(GDXDialogsVars.LOG_TAG, FallbackGDXTextPrompt.class.getSimpleName() + " dismiss ignored. (Fallback with empty methods)");
+		Gdx.app.debug(GDXDialogsVars.LOG_TAG, FallbackGDXTextPrompt.class.getSimpleName() + " dismiss" +
+				" ignored. (Fallback with empty methods)");
 		return this;
 	}
 

--- a/core/src/de/tomgrill/gdxdialogs/core/dialogs/GDXButtonDialog.java
+++ b/core/src/de/tomgrill/gdxdialogs/core/dialogs/GDXButtonDialog.java
@@ -24,64 +24,64 @@ public interface GDXButtonDialog {
 	 * Only on Android: When set true, user can click outside of the dialog and
 	 * the dialog will be closed. Has no effect on other operating systems.
 	 * 
-	 * @param cancelable
-	 * @return
+	 * @param cancelable this value will be set to the corresponding android property if applicable.
+	 * @return  The same instance that the method was called from.
 	 */
-	public GDXButtonDialog setCancelable(boolean cancelable);
+	GDXButtonDialog setCancelable(boolean cancelable);
 
 	/**
 	 * Shows the dialog. show() can only be called after build() has been called
 	 * else there might be strange behavior. You need to add at least one button
-	 * with addButton() before calling build().
+	 * with addButton() before calling build(). Runs asynchronously on a different thread.
 	 * 
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXButtonDialog show();
+	GDXButtonDialog show();
 
 	/**
 	 * Dismisses the dialog. You can show the dialog again.
 	 * 
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXButtonDialog dismiss();
+	GDXButtonDialog dismiss();
 
 	/**
 	 * Sets the {@link ButtonClickListener}
 	 * 
-	 * @param listener
-	 * @return
+	 * @param listener listener to be called when the event is triggered
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXButtonDialog setClickListener(ButtonClickListener listener);
+	GDXButtonDialog setClickListener(ButtonClickListener listener);
 
 	/**
 	 * Add new button to the dialog. You need to add at least one button.
 	 * 
-	 * @param label
-	 * @return
+	 * @param label Text of the added new button.
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXButtonDialog addButton(CharSequence label);
+	GDXButtonDialog addButton(CharSequence label);
 
 	/**
 	 * This builds the button and prepares for usage. You need to add at least
 	 * one button with addButton() before calling build().
 	 * 
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXButtonDialog build();
+	GDXButtonDialog build();
 
 	/**
 	 * Sets the message.
 	 * 
-	 * @param message
-	 * @return
+	 * @param message The text to be displayed at the body of the dialog.
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXButtonDialog setMessage(CharSequence message);
+	GDXButtonDialog setMessage(CharSequence message);
 
 	/**
 	 * Sets the title
 	 * 
-	 * @param title
-	 * @return
+	 * @param title String value to set the title
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXButtonDialog setTitle(CharSequence title);
+	GDXButtonDialog setTitle(CharSequence title);
 }

--- a/core/src/de/tomgrill/gdxdialogs/core/dialogs/GDXProgressDialog.java
+++ b/core/src/de/tomgrill/gdxdialogs/core/dialogs/GDXProgressDialog.java
@@ -20,39 +20,39 @@ public interface GDXProgressDialog {
 	/**
 	 * Sets the message.
 	 * 
-	 * @param message
-	 * @return
+	 * @param message The text to be displayed at the body of the dialog.
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXProgressDialog setMessage(CharSequence message);
+	GDXProgressDialog setMessage(CharSequence message);
 
 	/**
 	 * Sets the title
 	 * 
-	 * @param title
-	 * @return
+	 * @param title String value to set the title
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXProgressDialog setTitle(CharSequence title);
+	GDXProgressDialog setTitle(CharSequence title);
 
 	/**
 	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior.
-	 * 
-	 * @return
+	 * else there might be strange behavior. Runs asynchronously on a different thread.
+	 *
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXProgressDialog show();
+	GDXProgressDialog show();
 
 	/**
 	 * Dismisses the dialog. You can show the dialog again.
 	 * 
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXProgressDialog dismiss();
+	GDXProgressDialog dismiss();
 
 	/**
 	 * This builds the button and prepares for usage.
 	 * 
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXProgressDialog build();
+	GDXProgressDialog build();
 
 }

--- a/core/src/de/tomgrill/gdxdialogs/core/dialogs/GDXTextPrompt.java
+++ b/core/src/de/tomgrill/gdxdialogs/core/dialogs/GDXTextPrompt.java
@@ -22,70 +22,70 @@ public interface GDXTextPrompt {
 	/**
 	 * Sets the title
 	 *
-	 * @param title
-	 * @return
+	 * @param title String value to set the title
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt setTitle(CharSequence title);
+	GDXTextPrompt setTitle(CharSequence title);
 
 	/**
 	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior.
+	 * else there might be strange behavior. Runs asynchronously on a different thread.
 	 *
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt show();
+	GDXTextPrompt show();
 
 	/**
 	 * Dismisses the dialog. You can show the dialog again.
 	 *
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt dismiss();
+	GDXTextPrompt dismiss();
 
 	/**
 	 * This builds the button and prepares for usage.
 	 *
-	 * @return
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt build();
+	GDXTextPrompt build();
 
 	/**
 	 * Sets the message.
 	 *
-	 * @param message
-	 * @return
+	 * @param message The text to be displayed at the body of the dialog.
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt setMessage(CharSequence message);
+	GDXTextPrompt setMessage(CharSequence message);
 
 	/**
 	 * Sets the default value for the input field.
 	 *
-	 * @param message
-	 * @return
+	 * @param inputTip Placeholder for the text input field.
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt setValue(CharSequence message);
+	GDXTextPrompt setValue(CharSequence inputTip);
 
 	/**
 	 * Sets the label for the cancel button on the dialog.
 	 *
-	 * @param label
-	 * @return
+	 * @param label Text of the cancel button
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt setCancelButtonLabel(CharSequence label);
+	GDXTextPrompt setCancelButtonLabel(CharSequence label);
 
 	/**
 	 * Sets the label for the confirm button on the dialog.
 	 *
-	 * @param label
-	 * @return
+	 * @param label Text of the confirm button
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt setConfirmButtonLabel(CharSequence label);
+	GDXTextPrompt setConfirmButtonLabel(CharSequence label);
 
 	/**
 	 * Sets the {@link TextPromptListener}
 	 *
-	 * @param listener
-	 * @return
+	 * @param listener listener to be called when the event is triggered
+	 * @return The same instance that the method was called from.
 	 */
-	public GDXTextPrompt setTextPromptListener(TextPromptListener listener);
+	GDXTextPrompt setTextPromptListener(TextPromptListener listener);
 }

--- a/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXButtonDialog.java
+++ b/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXButtonDialog.java
@@ -22,7 +22,7 @@ import de.tomgrill.gdxdialogs.core.GDXDialogsVars;
 import de.tomgrill.gdxdialogs.core.dialogs.GDXButtonDialog;
 import de.tomgrill.gdxdialogs.core.listener.ButtonClickListener;
 
-import javax.swing.*;
+import javax.swing.JOptionPane;
 
 public class DesktopGDXButtonDialog implements GDXButtonDialog {
 
@@ -44,26 +44,18 @@ public class DesktopGDXButtonDialog implements GDXButtonDialog {
 		return this;
 	}
 
-	/**
-	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior. The boolean hangs the current thread if true.
-	 *
-	 *
-	 * @param hang if true hangs the thread witch it were called from
-	 * @return The same instance that the method was called from.
-	 */
-	public GDXButtonDialog show(boolean hang) {
+	@Override
+	public GDXButtonDialog show() {
 
 		if (!isBuild) {
 			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() +
 					" has not been build. Use build() before show().");
 		}
 
-		Thread t = new Thread(new Runnable() {
+		new Thread(new Runnable() {
 
 			@Override
 			public void run() {
-
 				Gdx.app.debug(
 						GDXDialogsVars.LOG_TAG, DesktopGDXButtonDialog.class.getSimpleName() + " now shown.");
 				Object[] options = new Object[labels.size];
@@ -84,21 +76,15 @@ public class DesktopGDXButtonDialog implements GDXButtonDialog {
 					listener.click(n);
 				}
 			}
-		});
-		if (hang) t.run();
-		else t.start();
+		}).start();
 
 		return this;
 	}
 
 	@Override
-	public GDXButtonDialog show() {
-		return show(false);
-	}
-
-	@Override
 	public GDXButtonDialog dismiss() {
-		Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXButtonDialog.class.getSimpleName() + " dismiss ignored. (Desktop ButtonDialogs cannot be dismissed)");
+		Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXButtonDialog.class.getSimpleName() + " dismiss " +
+				"ignored. (Desktop ButtonDialogs cannot be dismissed)");
 		return this;
 	}
 

--- a/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXButtonDialog.java
+++ b/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXButtonDialog.java
@@ -16,14 +16,13 @@
 
 package de.tomgrill.gdxdialogs.desktop.dialogs;
 
-import javax.swing.JOptionPane;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.utils.Array;
-
 import de.tomgrill.gdxdialogs.core.GDXDialogsVars;
 import de.tomgrill.gdxdialogs.core.dialogs.GDXButtonDialog;
 import de.tomgrill.gdxdialogs.core.listener.ButtonClickListener;
+
+import javax.swing.*;
 
 public class DesktopGDXButtonDialog implements GDXButtonDialog {
 
@@ -34,7 +33,7 @@ public class DesktopGDXButtonDialog implements GDXButtonDialog {
 
 	private Array<CharSequence> labels = new Array<CharSequence>();
 
-	boolean isBuild = false;
+	private boolean isBuild = false;
 
 	public DesktopGDXButtonDialog() {
 	}
@@ -45,11 +44,19 @@ public class DesktopGDXButtonDialog implements GDXButtonDialog {
 		return this;
 	}
 
-	@Override
-	public GDXButtonDialog show() {
+	/**
+	 * Shows the dialog. show() can only be called after build() has been called
+	 * else there might be strange behavior. The boolean hangs the current thread if true.
+	 *
+	 *
+	 * @param hang if true hangs the thread witch it were called from
+	 * @return The same instance that the method was called from.
+	 */
+	public GDXButtonDialog show(boolean hang) {
 
-		if (isBuild == false) {
-			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() before show().");
+		if (!isBuild) {
+			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() +
+					" has not been build. Use build() before show().");
 		}
 
 		Thread t = new Thread(new Runnable() {
@@ -57,7 +64,8 @@ public class DesktopGDXButtonDialog implements GDXButtonDialog {
 			@Override
 			public void run() {
 
-				Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXButtonDialog.class.getSimpleName() + " now shown.");
+				Gdx.app.debug(
+						GDXDialogsVars.LOG_TAG, DesktopGDXButtonDialog.class.getSimpleName() + " now shown.");
 				Object[] options = new Object[labels.size];
 
 				for (int i = 0; i < labels.size; i++) {
@@ -70,15 +78,22 @@ public class DesktopGDXButtonDialog implements GDXButtonDialog {
 					optionType = JOptionPane.YES_NO_CANCEL_OPTION;
 				}
 
-				int n = JOptionPane.showOptionDialog(null, (String) message, (String) title, optionType, JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
+				int n = JOptionPane.showOptionDialog(null, message, (String) title, optionType,
+						JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
 				if (listener != null) {
 					listener.click(n);
 				}
 			}
 		});
-		t.start();
+		if (hang) t.run();
+		else t.start();
 
 		return this;
+	}
+
+	@Override
+	public GDXButtonDialog show() {
+		return show(false);
 	}
 
 	@Override

--- a/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXProgressDialog.java
+++ b/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXProgressDialog.java
@@ -20,7 +20,8 @@ import com.badlogic.gdx.Gdx;
 import de.tomgrill.gdxdialogs.core.GDXDialogsVars;
 import de.tomgrill.gdxdialogs.core.dialogs.GDXProgressDialog;
 
-import javax.swing.*;
+import javax.swing.JOptionPane;
+import javax.swing.JDialog;
 
 public class DesktopGDXProgressDialog implements GDXProgressDialog {
 
@@ -46,16 +47,9 @@ public class DesktopGDXProgressDialog implements GDXProgressDialog {
 		return this;
 	}
 
-	/**
-	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior. The boolean hangs the current thread if true.
-	 *
-	 *
-	 * @param hang if true hangs the thread witch it were called from
-	 * @return The same instance that the method was called from.
-	 */
-	public GDXProgressDialog show(boolean hang) {
-		Thread t = new Thread(new Runnable() {
+	@Override
+	public GDXProgressDialog show() {
+		new Thread(new Runnable() {
 
 			@Override
 			public void run() {
@@ -64,15 +58,8 @@ public class DesktopGDXProgressDialog implements GDXProgressDialog {
 				dialog.setVisible(true);
 			}
 
-		});
-		if (hang) t.run();
-		else t.start();
+		}).start();
 		return this;
-	}
-
-	@Override
-	public GDXProgressDialog show() {
-		return show(false);
 	}
 
 

--- a/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXProgressDialog.java
+++ b/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXProgressDialog.java
@@ -16,13 +16,11 @@
 
 package de.tomgrill.gdxdialogs.desktop.dialogs;
 
-import javax.swing.JDialog;
-import javax.swing.JOptionPane;
-
 import com.badlogic.gdx.Gdx;
-
 import de.tomgrill.gdxdialogs.core.GDXDialogsVars;
 import de.tomgrill.gdxdialogs.core.dialogs.GDXProgressDialog;
+
+import javax.swing.*;
 
 public class DesktopGDXProgressDialog implements GDXProgressDialog {
 
@@ -48,20 +46,35 @@ public class DesktopGDXProgressDialog implements GDXProgressDialog {
 		return this;
 	}
 
-	@Override
-	public GDXProgressDialog show() {
+	/**
+	 * Shows the dialog. show() can only be called after build() has been called
+	 * else there might be strange behavior. The boolean hangs the current thread if true.
+	 *
+	 *
+	 * @param hang if true hangs the thread witch it were called from
+	 * @return The same instance that the method was called from.
+	 */
+	public GDXProgressDialog show(boolean hang) {
 		Thread t = new Thread(new Runnable() {
 
 			@Override
 			public void run() {
-				Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXProgressDialog.class.getSimpleName() + " now shown.");
+				Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXProgressDialog.class.getSimpleName() +
+						" now shown.");
 				dialog.setVisible(true);
 			}
 
 		});
-		t.start();
+		if (hang) t.run();
+		else t.start();
 		return this;
 	}
+
+	@Override
+	public GDXProgressDialog show() {
+		return show(false);
+	}
+
 
 	@Override
 	public GDXProgressDialog dismiss() {
@@ -74,7 +87,8 @@ public class DesktopGDXProgressDialog implements GDXProgressDialog {
 	@Override
 	public GDXProgressDialog build() {
 
-		optionPane = new JOptionPane(message, JOptionPane.INFORMATION_MESSAGE, JOptionPane.DEFAULT_OPTION, null, new Object[] {}, null);
+		optionPane = new JOptionPane(message, JOptionPane.INFORMATION_MESSAGE, JOptionPane.DEFAULT_OPTION, null,
+				new Object[] {}, null);
 		dialog = new JDialog();
 
 		dialog.setTitle((String) title);

--- a/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXTextPrompt.java
+++ b/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXTextPrompt.java
@@ -21,7 +21,7 @@ import de.tomgrill.gdxdialogs.core.GDXDialogsVars;
 import de.tomgrill.gdxdialogs.core.dialogs.GDXTextPrompt;
 import de.tomgrill.gdxdialogs.core.listener.TextPromptListener;
 
-import javax.swing.*;
+import javax.swing.JOptionPane;
 
 public class DesktopGDXTextPrompt implements GDXTextPrompt {
 
@@ -33,16 +33,9 @@ public class DesktopGDXTextPrompt implements GDXTextPrompt {
 	public DesktopGDXTextPrompt() {
 	}
 
-	/**
-	 * Shows the dialog. show() can only be called after build() has been called
-	 * else there might be strange behavior. The boolean hangs the current thread if true.
-	 *
-	 * @param hang if true hangs the thread witch it were called from
-	 * @return The same instance that the method was called from.
-	 */
-	public GDXTextPrompt show(boolean hang) {
-
-		Thread t = new Thread(new Runnable() {
+	@Override
+	public GDXTextPrompt show() {
+		new Thread(new Runnable() {
 
 			@Override
 			public void run() {
@@ -62,16 +55,9 @@ public class DesktopGDXTextPrompt implements GDXTextPrompt {
 					}
 				}
 			}
-		});
+		}).start();
 
-		if (hang) t.run();
-		else t.start();
 		return this;
-	}
-
-	@Override
-	public GDXTextPrompt show() {
-		return show(false);
 	}
 
 	@Override
@@ -114,7 +100,8 @@ public class DesktopGDXTextPrompt implements GDXTextPrompt {
 
 	@Override
 	public GDXTextPrompt dismiss() {
-		Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXTextPrompt.class.getSimpleName() + " dismiss ignored. (Desktop TextPrompt cannot be dismissed)");
+		Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXTextPrompt.class.getSimpleName() + " dismiss " +
+				"ignored. (Desktop TextPrompt cannot be dismissed)");
 		return this;
 	}
 

--- a/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXTextPrompt.java
+++ b/desktop/src/de/tomgrill/gdxdialogs/desktop/dialogs/DesktopGDXTextPrompt.java
@@ -16,13 +16,12 @@
 
 package de.tomgrill.gdxdialogs.desktop.dialogs;
 
-import javax.swing.JOptionPane;
-
 import com.badlogic.gdx.Gdx;
-
 import de.tomgrill.gdxdialogs.core.GDXDialogsVars;
 import de.tomgrill.gdxdialogs.core.dialogs.GDXTextPrompt;
 import de.tomgrill.gdxdialogs.core.listener.TextPromptListener;
+
+import javax.swing.*;
 
 public class DesktopGDXTextPrompt implements GDXTextPrompt {
 
@@ -34,18 +33,29 @@ public class DesktopGDXTextPrompt implements GDXTextPrompt {
 	public DesktopGDXTextPrompt() {
 	}
 
-	@Override
-	public GDXTextPrompt show() {
+	/**
+	 * Shows the dialog. show() can only be called after build() has been called
+	 * else there might be strange behavior. The boolean hangs the current thread if true.
+	 *
+	 * @param hang if true hangs the thread witch it were called from
+	 * @return The same instance that the method was called from.
+	 */
+	public GDXTextPrompt show(boolean hang) {
 
 		Thread t = new Thread(new Runnable() {
 
 			@Override
 			public void run() {
-				Gdx.app.debug(GDXDialogsVars.LOG_TAG, DesktopGDXTextPrompt.class.getSimpleName() + " now shown");
-				String response = JOptionPane.showInputDialog(null, (String) message, (String) title, JOptionPane.QUESTION_MESSAGE);
+				Gdx.app.debug(GDXDialogsVars.LOG_TAG,
+						DesktopGDXTextPrompt.class.getSimpleName() + " now shown");
+				String response = JOptionPane.showInputDialog(null, message, (String) title,
+						JOptionPane.QUESTION_MESSAGE);
 
 				if (listener != null) {
-					if (response == null || (response != null && ("".equals(response)))) {
+					//if the first is true the second is implicitly always true
+					//e.g bool j, f;   ((j or (not j and f)) == (j or f)) == true
+					//Regardless of j and f values.
+					if (response == null || "".equals(response)) {
 						listener.cancel();
 					} else {
 						listener.confirm(response);
@@ -54,8 +64,14 @@ public class DesktopGDXTextPrompt implements GDXTextPrompt {
 			}
 		});
 
-		t.start();
+		if (hang) t.run();
+		else t.start();
 		return this;
+	}
+
+	@Override
+	public GDXTextPrompt show() {
+		return show(false);
 	}
 
 	@Override
@@ -92,7 +108,7 @@ public class DesktopGDXTextPrompt implements GDXTextPrompt {
 	}
 
 	@Override
-	public GDXTextPrompt setValue(CharSequence message) {
+	public GDXTextPrompt setValue(CharSequence inputTip) {
 		return this;
 	}
 

--- a/html/src/de/tomgrill/gdxdialogs/html/dialogs/HTMLGDXTextPrompt.java
+++ b/html/src/de/tomgrill/gdxdialogs/html/dialogs/HTMLGDXTextPrompt.java
@@ -16,16 +16,13 @@
 
 package de.tomgrill.gdxdialogs.html.dialogs;
 
-import com.badlogic.gdx.utils.ObjectMap;
-
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 import de.tomgrill.gdxdialogs.core.dialogs.GDXButtonDialog;
 import de.tomgrill.gdxdialogs.core.dialogs.GDXTextPrompt;
 import de.tomgrill.gdxdialogs.core.listener.TextPromptListener;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @SuppressWarnings("JniMissingFunction")
 public class HTMLGDXTextPrompt implements GDXTextPrompt {
@@ -44,7 +41,7 @@ public class HTMLGDXTextPrompt implements GDXTextPrompt {
 
     @Override
     public GDXTextPrompt show() {
-        if (isBuild == false) {
+        if (!isBuild) {
             throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() before show().");
         }
         showJSTextPrompt(toString());
@@ -53,7 +50,7 @@ public class HTMLGDXTextPrompt implements GDXTextPrompt {
 
     @Override
     public GDXTextPrompt dismiss() {
-        if (isBuild == false) {
+        if (!isBuild) {
             throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() before dismiss().");
         }
         dismissJSTextPrompt(toString());
@@ -74,8 +71,8 @@ public class HTMLGDXTextPrompt implements GDXTextPrompt {
     }
 
     @Override
-    public GDXTextPrompt setValue(CharSequence message) {
-        this.value = (String) message;
+    public GDXTextPrompt setValue(CharSequence inputTip) {
+        this.value = (String) inputTip;
         return this;
     }
 
@@ -112,9 +109,8 @@ public class HTMLGDXTextPrompt implements GDXTextPrompt {
     }
 
     public static void confirm(String id, String text) {
-        Iterator iterator = dialogs.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry entry = (Map.Entry) iterator.next();
+        for (Object o : dialogs.entrySet()) {
+            Map.Entry entry = (Map.Entry) o;
             if (id.equals(entry.getKey())) {
                 HTMLGDXTextPrompt prompt = (HTMLGDXTextPrompt) (entry.getValue());
                 if (prompt.listener != null) {

--- a/ios-moe/src/de/tomgrill/gdxdialogs/iosmoe/dialogs/IOSMOEGDXButtonDialog.java
+++ b/ios-moe/src/de/tomgrill/gdxdialogs/iosmoe/dialogs/IOSMOEGDXButtonDialog.java
@@ -49,7 +49,8 @@ public class IOSMOEGDXButtonDialog implements GDXButtonDialog {
 	@Override
 	public GDXButtonDialog show() {
 		if (alertView == null) {
-			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() before show().");
+			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been built. Use build() " +
+					"before show().");
 		}
 		Gdx.app.debug(GDXDialogsVars.LOG_TAG, IOSMOEGDXButtonDialog.class.getSimpleName() + " now shown.");
 		alertView.show();
@@ -59,7 +60,8 @@ public class IOSMOEGDXButtonDialog implements GDXButtonDialog {
 	@Override
 	public GDXButtonDialog dismiss() {
 		if (alertView == null) {
-			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() before dismiss().");
+			throw new RuntimeException(GDXButtonDialog.class.getSimpleName() + " has not been build. Use build() " +
+					"before dismiss().");
 		}
 		Gdx.app.debug(GDXDialogsVars.LOG_TAG, IOSMOEGDXButtonDialog.class.getSimpleName() + " dismissed.");
 		alertView.dismissWithClickedButtonIndexAnimated(-1, false);
@@ -103,7 +105,8 @@ public class IOSMOEGDXButtonDialog implements GDXButtonDialog {
 	public GDXButtonDialog build() {
 		Gdx.app.log(TAG, "build 1");
 		UIAlertViewDelegate delegate = new UIAlertViewDelegate() {
-			@Override public void alertViewDidDismissWithButtonIndex (UIAlertView alertView, @NInt long buttonIndex) {
+			@Override
+			public void alertViewDidDismissWithButtonIndex (UIAlertView alertView, @NInt long buttonIndex) {
 				performClickOnButton(buttonIndex);
 			}
 		};

--- a/ios-moe/src/de/tomgrill/gdxdialogs/iosmoe/dialogs/IOSMOEGDXTextPrompt.java
+++ b/ios-moe/src/de/tomgrill/gdxdialogs/iosmoe/dialogs/IOSMOEGDXTextPrompt.java
@@ -103,7 +103,7 @@ public class IOSMOEGDXTextPrompt implements GDXTextPrompt {
 	}
 
 	@Override
-	public GDXTextPrompt setValue(CharSequence value) {
+	public GDXTextPrompt setValue(CharSequence inputTip) {
 		return this;
 	}
 

--- a/ios/src/de/tomgrill/gdxdialogs/ios/dialogs/IOSGDXTextPrompt.java
+++ b/ios/src/de/tomgrill/gdxdialogs/ios/dialogs/IOSGDXTextPrompt.java
@@ -130,7 +130,7 @@ public class IOSGDXTextPrompt implements GDXTextPrompt {
 	}
 
 	@Override
-	public GDXTextPrompt setValue(CharSequence value) {
+	public GDXTextPrompt setValue(CharSequence inputTip) {
 		return this;
 	}
 


### PR DESCRIPTION
- Updates android build tools. To the latest version (25.0.2).
- Adds optional, intentional, hanging of the main thread. For the desktop and android platforms, implemented with the use of polymorphism, everything before the change will keep working as before.
- Fixes bunch of pointless boolean checks. All commented why.
- Improvements to the documentation. Self-explanatory.